### PR TITLE
Adjustments and Additions to modules

### DIFF
--- a/map_gen/maps/april_fools/modules/auto_build.lua
+++ b/map_gen/maps/april_fools/modules/auto_build.lua
@@ -1,0 +1,122 @@
+-- auto-builds the item in a random players cursor if possible
+-- WIP
+
+local Global = require 'utils.global'
+
+local BASE_TARGETS = 0 -- how many targets per level
+local BUILD_INTERVAL = 60 * 5 -- 5sec
+local CHANGE_TARGET_INTERVAL = _DEBUG and 60 * 1 or 60 * 100 -- 100sec
+
+local _global = {
+  level = 0, -- 1 to enabled by defualt
+  max_level = 10,
+  rand_targets = {},
+}
+
+Global.register(_global, function(tbl) _global = tbl end)
+
+-- ============================================================================
+
+local function clear_targets()
+  for j=1, #_global.rand_targets do
+    _global.rand_targets[j] = nil
+  end
+end
+
+local function change_targets()
+  if not (_global and _global.level > 0) then
+    -- Level not enabled
+    return
+  end
+
+  local num_targets = math.min(#game.connected_players, _global.level * BASE_TARGETS)
+
+  for j=1, num_targets do
+    _global.rand_targets[j] = nil
+  end
+
+  if #game.connected_players > 0 then
+    for j=1, num_targets do
+      local player_index = math.random(1, #game.connected_players)
+      _global.rand_targets[j] = game.connected_players[player_index]
+    end
+  end
+end
+
+local function try_auto_build()
+  if not (_global and _global.rand_targets and (#_global.rand_targets > 0)) then
+    -- No targets
+    return
+  end
+-- useful functions: 
+-- surface.find_non_colliding_position, surface.find_non_colliding_position_in_box
+-- player.can_build_from_cursor, player.build_from_cursor
+--
+  local cursor_item = nil
+  local surface = nil
+  local build_position = nil
+  for _, player in pairs(_global.rand_targets) do
+    if (player and player.valid) then
+      surface = player.surface
+      if player.cursor_stack.valid_for_read then
+        cursor_item = player.cursor_stack.name
+      else
+        return --cursor not valud to read, i.e. just before spawning
+      end
+      if cursor_item == nil then
+        return -- no item in cursor
+      end
+      -- randomly pick a position near the player, check for a valid nearby location
+      build_position = {player.position.x + math.random(-5,5),player.position.y + math.random(-5,5)}
+      build_position = surface.find_non_colliding_position(cursor_item,build_position, 5, .1)
+      if build_position == nil then
+        return -- no valud build position
+      end
+      -- must be extra cautious with surface & players as they may be teleported across temporary surfaces
+      if (surface and surface.valid and build_position) then
+        if player.can_build_from_cursor{position = build_position} then
+          player.build_from_cursor{position = build_position}
+        end
+      end
+    end
+  end
+end
+-- ============================================================================
+
+local Public = {}
+
+Public.name = 'Auto Build'
+
+Public.on_nth_tick = {
+  [CHANGE_TARGET_INTERVAL] = change_targets,
+  [BUILD_INTERVAL] = try_auto_build,
+}
+
+Public.level_increase = function()
+  _global.level = math.min(_global.level + 1, _global.max_level)
+end
+
+Public.level_decrease = function()
+  _global.rand_targets[_global.level] = nil
+  _global.level = math.max(_global.level - 1, 0)
+end
+
+Public.level_reset = function()
+  clear_targets()
+  _global.level = 0
+end
+
+Public.level_set = function(val)
+  clear_targets()
+  _global.level = val
+end
+
+Public.level_get = function()
+  return _global.level
+end
+
+Public.max_get = function()
+  return _global.max_level
+end
+
+return Public

--- a/map_gen/maps/april_fools/modules/auto_build.lua
+++ b/map_gen/maps/april_fools/modules/auto_build.lua
@@ -3,7 +3,7 @@
 
 local Global = require 'utils.global'
 
-local BASE_TARGETS = 0 -- how many targets per level
+local BASE_TARGETS = 1 -- how many targets per level
 local BUILD_INTERVAL = 60 * 5 -- 5sec
 local CHANGE_TARGET_INTERVAL = _DEBUG and 60 * 1 or 60 * 100 -- 100sec
 

--- a/map_gen/maps/april_fools/modules/auto_build.lua
+++ b/map_gen/maps/april_fools/modules/auto_build.lua
@@ -48,13 +48,13 @@ local function try_auto_build()
     -- No targets
     return
   end
--- useful functions: 
+-- useful functions:
 -- surface.find_non_colliding_position, surface.find_non_colliding_position_in_box
 -- player.can_build_from_cursor, player.build_from_cursor
 --
-  local cursor_item = nil
-  local surface = nil
-  local build_position = nil
+  local cursor_item
+  local surface
+  local build_position
   for _, player in pairs(_global.rand_targets) do
     if (player and player.valid) then
       surface = player.surface

--- a/map_gen/maps/april_fools/modules/biter_ores.lua
+++ b/map_gen/maps/april_fools/modules/biter_ores.lua
@@ -1,0 +1,115 @@
+-- Spawns ores on biter death
+-- WIP
+
+local Global = require 'utils.global'
+local math = require 'utils.math'
+
+local RANDOM_ORES = false
+local BASE_ORE_AMOUNT = 5 -- ore spawned per small biter, per level
+local BASIC_ORES = {'coal','stone','iron-ore','copper-ore'}
+local URANIUM_CHANCE = 5 -- chance for uranium ore. All others will share the remaining chance
+local ORE_SEARCH_RADIUS = RANDOM_ORES and 1 or 20 -- how far away do we look for ores before spawning a new one
+
+local _global = {
+  level = 0, --1 to enabled by defualt
+  max_level = 10,
+}
+
+Global.register(_global, function(tbl) _global = tbl end)
+
+local ENEMY_ORE_MULTIPLIER = { -- roughly in order of evolution percentage required to see these biters
+  ['small-biter']           = 1,
+  ['small-spitter']         = 2,
+  ['small-worm-turret']     = 5,
+  ['medium-biter']          = 2,
+  ['medium-spitter']        = 4,
+  ['medium-worm-turret']    = 10,
+  ['big-biter']             = 5,
+  ['big-spitter']           = 10,
+  ['big-worm-turret']       = 25,
+  ['behemoth-biter']        = 10,
+  ['behemoth-spitter']      = 20,
+  ['behemoth-worm-turret']  = 50,
+  ['biter-spawner']         = 10,
+  ['spitter-spawner']       = 20
+}
+
+-- ============================================================================
+local function spawn_ores_on_death(event)
+  if not (_global and _global.level > 0) then
+    -- Level not enabled
+    return
+  end
+
+  -- check if entity is biter, worm, or spawner
+  local entity = event.entity
+  if entity.type ~= 'unit' and entity.type ~= 'turret' and entity.type ~= 'unit-spawner' then
+    return
+  end
+  local ore_amount_to_add = _global.level * ENEMY_ORE_MULTIPLIER[entity.name] * BASE_ORE_AMOUNT
+  local position = entity.position
+  local surface = entity.surface
+  local ore_type = nil
+
+  --first, look for ores on the tile the biter died, and add ores to that ore if possible
+  local found_ores = surface.find_entities_filtered{position = position, radius = 1, type = 'resource'}
+  if #found_ores == 0 then
+    --no ore found on biter tile
+    found_ores = surface.find_entities_filtered{position = position, radius = ORE_SEARCH_RADIUS, type = 'resource'}
+    if #found_ores == 0 then
+      --no ore found nearby, decide on a new ore to spawn
+      if math.random(1,100) < URANIUM_CHANCE then
+        ore_type = 'uranium-ore'
+      else
+        ore_type = BASIC_ORES[math.random(1,#BASIC_ORES)]
+      end
+    else
+      -- found nearby ore, use that one
+      ore_type = found_ores[math.random(1,#found_ores)].name
+    end
+
+    if surface.get_tile(position).collides_with("ground-tile") then
+      surface.create_entity{name = ore_type, position = position, amount = ore_amount_to_add}
+    end
+    --return since we might have changed found_ores
+    return
+  else
+    -- ore on biters tile, add to that ore instead
+    found_ores[1].amount = found_ores[1].amount + ore_amount_to_add
+  end
+end
+
+-- ============================================================================
+local Public = {}
+
+Public.name = 'Biter Ores'
+
+Public.events = {
+  [defines.events.on_entity_died] = spawn_ores_on_death
+}
+
+Public.level_increase = function()
+  _global.level = math.min(_global.level + 1, _global.max_level)
+end
+
+Public.level_decrease = function()
+  _global.level = math.max(_global.level - 1, 0)
+end
+
+Public.level_reset = function()
+  _global.level = 0
+end
+
+Public.level_set = function(val)
+  _global.level = val
+end
+
+Public.level_get = function()
+  return _global.level
+end
+
+Public.max_get = function()
+  return _global.max_level
+end
+
+return Public

--- a/map_gen/maps/april_fools/modules/biter_ores.lua
+++ b/map_gen/maps/april_fools/modules/biter_ores.lua
@@ -52,7 +52,7 @@ local function spawn_ores_on_death(event)
   local ore_type = nil
 
   --first, look for ores on the tile the biter died, and add ores to that ore if possible
-  local found_ores = surface.find_entities_filtered{position = position, radius = 1, type = 'resource'}
+  local found_ores = surface.find_entities_filtered{position = position, radius = .1, type = 'resource'}
   if #found_ores == 0 then
     --no ore found on biter tile
     found_ores = surface.find_entities_filtered{position = position, radius = ORE_SEARCH_RADIUS, type = 'resource'}

--- a/map_gen/maps/april_fools/modules/biter_ores.lua
+++ b/map_gen/maps/april_fools/modules/biter_ores.lua
@@ -49,7 +49,7 @@ local function spawn_ores_on_death(event)
   local ore_amount_to_add = _global.level * ENEMY_ORE_MULTIPLIER[entity.name] * BASE_ORE_AMOUNT
   local position = entity.position
   local surface = entity.surface
-  local ore_type = nil
+  local ore_type
 
   --first, look for ores on the tile the biter died, and add ores to that ore if possible
   local found_ores = surface.find_entities_filtered{position = position, radius = .1, type = 'resource'}

--- a/map_gen/maps/april_fools/modules/enemy_turrets.lua
+++ b/map_gen/maps/april_fools/modules/enemy_turrets.lua
@@ -6,6 +6,7 @@ local Global = require 'utils.global'
 
 local BASE_PERCENT = 0.05
 local MAX_RAND = 100
+local LASER_SHOTS_PER_LEVEL = 10 -- No idea what a good number is here balance wise.
 
 local _global = {
   level = 0,
@@ -36,7 +37,23 @@ local TURRET_ACTIONS = {
         raise_built = false,
         move_stuck_players = true,
       }
-      entity.surface.create_entity{
+	  --- find that interface we just made
+	  local entities = entity.surface.find_entities_filtered{
+		name = 'hidden-electric-energy-interface',
+		position = entity.position,
+		radius = 2,
+	  }
+	  	--- Set energy interface
+	  local total_power = 800000 * LASER_SHOTS_PER_LEVEL * (_global.level or 1) --- 800000 is 1 shot of the laser turret
+	  for i=1, #entities do
+      if (entities[i] and entities[i].valid) then
+        entities[i].electric_buffer_size = total_power
+        entities[i].power_production = 0
+        entities[i].power_usage = 0
+        entities[i].energy = total_power
+      end
+	  end
+	  entity.surface.create_entity{
         name = 'small-electric-pole',
         force = 'enemy',
         position = entity.position,

--- a/map_gen/maps/april_fools/modules/enemy_turrets.lua
+++ b/map_gen/maps/april_fools/modules/enemy_turrets.lua
@@ -43,7 +43,7 @@ local TURRET_ACTIONS = {
 		position = entity.position,
 		radius = 2,
 	  }
-	  	--- Set energy interface
+    --- Set energy interface
 	  local total_power = 800000 * LASER_SHOTS_PER_LEVEL * (_global.level or 1) --- 800000 is 1 shot of the laser turret
 	  for i=1, #entities do
       if (entities[i] and entities[i].valid) then

--- a/map_gen/maps/april_fools/modules/explosion_scare.lua
+++ b/map_gen/maps/april_fools/modules/explosion_scare.lua
@@ -61,7 +61,7 @@ local function explode_targets()
     -- No targets
     return
   end
-  local index_from_level = math.clamp(_global.level, 1, #EXPLOSION_GROUPS)
+  local index_from_level = math.clamp(_global.level, 1, #EXPLOSION_GROUPS) --luacheck: ignore 143 math.clamp does in fact exist
   local explosions = EXPLOSION_GROUPS[index_from_level]
 
   for _, player in pairs(_global.rand_target) do

--- a/map_gen/maps/april_fools/modules/explosion_scare.lua
+++ b/map_gen/maps/april_fools/modules/explosion_scare.lua
@@ -1,0 +1,120 @@
+-- Spawns random non-damaging explosions on random players as a jump-scare
+-- WIP
+local Global = require 'utils.global'
+
+local BASE_TARGETS = 1 -- how many targets per level
+local EXPLOSION_INTERVAL = _DEBUG and 60 * 5 or 60 * 60 -- 60sec
+local CHANGE_TARGET_INTERVAL = _DEBUG and 60 * 10 or 60 * 180 -- 180 seconds
+
+
+local _global = {
+  level = 0, -- 1 to enabled by defualt
+  max_level = 10,
+  rand_target = {},
+}
+
+Global.register(_global, function(tbl) _global = tbl end)
+
+local EXPLOSION_GROUPS = {
+  { 'water-splash' },
+  { 'water-splash', 'explosion' },
+  { 'water-splash', 'explosion', 'land-mine-explosion' },
+  { 'explosion', 'land-mine-explosion', 'grenade-explosion' },
+  { 'land-mine-explosion', 'grenade-explosion', 'medium-explosion' },
+  { 'grenade-explosion', 'medium-explosion' },
+  { 'medium-explosion', 'big-explosion' },
+  { 'big-explosion', 'massive-explosion', 'big-artillery-explosion' },
+  { 'massive-explosion', 'big-artillery-explosion' },
+  { 'massive-explosion', 'big-artillery-explosion', 'nuke-explosion' },
+}
+-- ============================================================================
+
+local function clear_targets()
+  for j=1, #_global.rand_target do
+    _global.rand_target[j] = nil
+  end
+end
+
+local function change_targets()
+  if not (_global and (_global.level > 0)) then
+    -- Level not enabled
+    return
+  end
+  -- without taking the min of connected players, and the desired targets, it's possible for 1 player to get ALL the explosions
+  -- The code would then randomly choose an explosion for each target, so you might get a water splash and a normal explosion at the same time.
+  local num_targets = math.min(_global.level * BASE_TARGETS, #game.connected_players)
+
+  for j=1, num_targets do
+    _global.rand_target[j] = nil
+  end
+
+  if #game.connected_players > 0 then
+    for j=1, num_targets do
+      local player_index = math.random(1, #game.connected_players)
+      _global.rand_target[j] = game.connected_players[player_index]
+    end
+  end
+end
+
+local function explode_targets()
+  if not (_global and _global.rand_target and (#_global.rand_target > 0)) then
+    -- No targets
+    return
+  end
+  local index_from_level = math.clamp(_global.level, 1, #EXPLOSION_GROUPS)
+  local explosions = EXPLOSION_GROUPS[index_from_level]
+
+  for _, player in pairs(_global.rand_target) do
+    if (player and player.valid) then
+      local surface = player.surface
+      local position = player.position
+      local explosion_index = math.random(1, #explosions)
+      -- must be extra cautious with surface & players as they may be teleported across temporary surfaces
+      if (surface and surface.valid and position) then
+        surface.create_entity{
+          name = explosions[explosion_index],
+          position = position,
+        }
+      end
+    end
+  end
+end
+
+-- ============================================================================
+
+local Public = {}
+Public.name = 'Explosion Scare'
+
+Public.on_nth_tick = {
+  [CHANGE_TARGET_INTERVAL] = change_targets,
+  [EXPLOSION_INTERVAL] = explode_targets,
+}
+
+Public.level_increase = function()
+  _global.level = math.min(_global.level + 1, _global.max_level)
+end
+
+Public.level_decrease = function()
+  _global.rand_target[_global.level] = nil
+  _global.level = math.max(_global.level - 1, 0)
+end
+
+Public.level_reset = function()
+  clear_targets()
+  _global.level = 0
+end
+
+Public.level_set = function(val)
+  clear_targets()
+  _global.level = val
+end
+
+Public.level_get = function()
+  return _global.level
+end
+
+Public.max_get = function()
+  return _global.max_level
+end
+
+return Public

--- a/map_gen/maps/april_fools/modules/floor_is_lava.lua
+++ b/map_gen/maps/april_fools/modules/floor_is_lava.lua
@@ -26,6 +26,9 @@ local function damage_afk_players()
     if (player and player.valid and player.character and player.character.valid) then
       if player.afk_time > ALLOWED_AFK_TIME then
         player.character.damage(BASE_DAMAGE * _global.level, 'enemy')
+        if _global.level >= _global.max_level/2 then
+          player.surface.create_entity({name = 'fire-flame', position = player.position})
+        end
       end
     end
   end

--- a/map_gen/maps/april_fools/modules/meteOres.lua
+++ b/map_gen/maps/april_fools/modules/meteOres.lua
@@ -38,7 +38,7 @@ local ALL_ORES = {'coal','stone','iron-ore','copper-ore','uranium-ore'}
 
 local function drop_meteors()
   --[[ Large function, lots of steps. May want to split out into several functions later
-      [X] Find a player to use their surface 
+      [X] Find a player to use their surface
       [X] Generate a random position on the map
       [X] Spawn a rock
       [X] Damage Nearby Entities
@@ -49,9 +49,9 @@ local function drop_meteors()
     -- Level not enabled
     return
   end
-  local player = nil
-  local surface = nil
-  for meteor_num=1, METEOR_COUNT do
+  local player
+  local surface
+  for _ = 1, METEOR_COUNT do
     -- find a random player so we can use their surface
     if #game.connected_players > 0 then
       player = game.connected_players[math.random(1, #game.connected_players)]
@@ -84,11 +84,12 @@ local function drop_meteors()
         end
       end
     end
-    
+
     -- Select ores to spawn
     local ore_selector = math.random(1,100)
-    local ores = nil
-    local ore_type = nil
+    local ores
+    local ore_type
+    local ore_amount
     if ore_selector > 100 - 5 * ORE_COMPLEXITY then
       ores = 'individual'
       ore_type = ALL_ORES[math.random(1, #ALL_ORES)]
@@ -101,8 +102,8 @@ local function drop_meteors()
     for y = -METEOR_SIZE, METEOR_SIZE do
       for x = -METEOR_SIZE, METEOR_SIZE do
         if (x * x + y * y < METEOR_SIZE * METEOR_SIZE) then
-          a = (METEOR_SIZE + 1 - math.abs(x)) * 10
-          b = (METEOR_SIZE + 1 - math.abs(y)) * 10
+          local a = (METEOR_SIZE + 1 - math.abs(x)) * 10
+          local b = (METEOR_SIZE + 1 - math.abs(y)) * 10
           if a < b then
             ore_amount = math.random(a * ORE_DENSITY - a * (ORE_DENSITY - 8), a * ORE_DENSITY + a * (ORE_DENSITY - 8))
           end

--- a/map_gen/maps/april_fools/modules/meteOres.lua
+++ b/map_gen/maps/april_fools/modules/meteOres.lua
@@ -1,0 +1,174 @@
+-- Spawns "meteors" that spawn a boulder, and dense random ores, and biters, and maybe nests
+-- WIP
+
+local Global = require 'utils.global'
+local math = require 'utils.math'
+
+local SPAWN_INTERVAL = _DEBUG and 60 * 1 or 60 * 180 -- 180sec
+local UNIT_COUNT = 10 -- Balance Number of units spawned per enemy listed in each ENEMY_GROUP
+local METEOR_COUNT = 1 -- meteors per spawn interval
+local METEOR_SIZE = 7 -- radius, Balance
+local METEOR_DAMAGE = 50 -- Balance
+local ORE_DENSITY = 10 -- Balance, Must be at least 8?
+local ORE_COMPLEXITY = 5 -- Percent chance for each of the 5 ore types to spawn, otherwise mixed ores without uranium will spawn.
+
+local _global = {
+  level = 0, --1 to enabled by defualt
+  max_level = 10,
+}
+
+Global.register(_global, function(tbl) _global = tbl end)
+
+local ENEMY_GROUPS = {
+  { 'small-biter'},
+  { 'small-biter', 'small-spitter', 'small-worm-turret', 'biter-spawner'},
+  { 'small-biter', 'small-spitter','medium-biter','small-worm-turret', 'biter-spawner', 'spitter-spawner'  },
+  { 'small-biter', 'small-spitter','medium-biter', 'medium-spitter','small-worm-turret', 'biter-spawner', 'spitter-spawner'  },
+  { 'medium-biter', 'medium-spitter', 'big-biter', 'big-spitter','small-worm-turret','medium-worm-turret', 'biter-spawner', 'spitter-spawner'  },
+  { 'medium-biter', 'medium-spitter', 'big-biter', 'big-spitter', 'big-worm-turret','medium-worm-turret', 'biter-spawner', 'spitter-spawner'  },
+  { 'big-biter', 'big-spitter','behemoth-biter', 'behemoth-spitter', 'medium-worm-turret','big-worm-turret', 'biter-spawner', 'spitter-spawner'  },
+  { 'big-biter', 'big-spitter','behemoth-biter', 'behemoth-spitter', 'medium-worm-turret', 'big-worm-turret', 'biter-spawner', 'spitter-spawner'  },
+  { 'big-biter', 'big-spitter','behemoth-biter', 'behemoth-spitter', 'big-worm-turret','behemoth-worm-turret', 'biter-spawner', 'spitter-spawner' },
+  { 'behemoth-biter', 'behemoth-spitter', 'behemoth-worm-turret', 'biter-spawner', 'spitter-spawner' },
+}
+local BASIC_ORES = {'coal','stone','iron-ore','copper-ore'}
+local ALL_ORES = {'coal','stone','iron-ore','copper-ore','uranium-ore'}
+
+-- ============================================================================
+
+local function drop_meteors()
+  --[[ Large function, lots of steps. May want to split out into several functions later
+      [X] Find a player to use their surface 
+      [X] Generate a random position on the map
+      [X] Spawn a rock
+      [X] Damage Nearby Entities
+      [X] Spawn Ores
+      [X] Spawn Biters
+  --]]
+  if not (_global and _global.level > 0) then
+    -- Level not enabled
+    return
+  end
+  local player = nil
+  local surface = nil
+  for meteor_num=1, METEOR_COUNT do
+    -- find a random player so we can use their surface
+    if #game.connected_players > 0 then
+      player = game.connected_players[math.random(1, #game.connected_players)]
+      surface = player.surface
+    else
+      return -- no connected players
+    end
+
+    -- generate a random position in a random chunk
+    local chunk_position = surface.get_random_chunk()
+    local rand_x = math.random(0, 31)
+    local rand_y = math.random(0, 31)
+    local map_position = {x = chunk_position.x * 32 + rand_x, y = chunk_position.y * 32 + rand_y}
+
+    -- Spawn Rock
+    if surface.get_tile(map_position).collides_with('ground-tile') then
+      surface.create_entity({name = 'rock-huge', position = map_position, move_stuck_players = true,})
+    end
+
+    -- Find nearby entities
+    local damaged_entities = surface.find_entities_filtered{position = map_position, radius = METEOR_SIZE}
+    -- Damage nearby entities
+    if damaged_entities == nil then
+      return
+    else
+      for _, entity in ipairs(damaged_entities) do
+        if entity.is_entity_with_health then
+          entity.damage(METEOR_DAMAGE,'enemy','impact')
+        end
+      end
+    end
+    
+    -- Select ores to spawn
+    local ore_selector = math.random(1,100)
+    local ores = nil
+    local ore_type = nil
+    if ore_selector > 100 - 5 * ORE_COMPLEXITY then
+      ores = 'individual'
+      ore_type = ALL_ORES[math.random(1, #ALL_ORES)]
+    else
+      ores = 'mixed'
+    end
+    -- Spawn ores
+    -- Loop over x, y, check in the circle, and spawn ores in a natural density
+    -- aka code adapted from wube wiki console page for spawning a resource patch
+    for y = -METEOR_SIZE, METEOR_SIZE do
+      for x = -METEOR_SIZE, METEOR_SIZE do
+        if (x * x + y * y < METEOR_SIZE * METEOR_SIZE) then
+          a = (METEOR_SIZE + 1 - math.abs(x)) * 10
+          b = (METEOR_SIZE + 1 - math.abs(y)) * 10
+          if a < b then
+            ore_amount = math.random(a * ORE_DENSITY - a * (ORE_DENSITY - 8), a * ORE_DENSITY + a * (ORE_DENSITY - 8))
+          end
+          if b < a then
+            ore_amount = math.random(b * ORE_DENSITY - b * (ORE_DENSITY - 8), b * ORE_DENSITY + b * (ORE_DENSITY - 8))
+          end
+          if surface.get_tile(map_position.x + x, map_position.y + y).collides_with('ground-tile') then
+            if ores == 'mixed' then
+              ore_type = BASIC_ORES[math.random(1, #BASIC_ORES)]
+            end
+            surface.create_entity({name=ore_type, amount=ore_amount, position={map_position.x + x, map_position.y + y}})
+          end
+        end
+      end
+    end
+    -- spawn biters
+    local index_from_level = math.clamp(_global.level, 1, #ENEMY_GROUPS)
+    local biters = ENEMY_GROUPS[index_from_level]
+    for i=1, UNIT_COUNT do
+      local unit_index = math.random(1, #biters)
+      local biter_position = {
+        map_position.x + math.random(-METEOR_SIZE, METEOR_SIZE),
+        map_position.y + math.random(-METEOR_SIZE, METEOR_SIZE)}
+      if surface.get_tile(biter_position).collides_with('ground-tile') then
+        surface.create_entity{
+          name = biters[unit_index],
+          position = biter_position,
+          force = 'enemy',
+          -- target = player.character, -- try without player target? Will they behave normally?
+        }
+      end
+    end
+  end
+end
+
+-- ============================================================================
+
+local Public = {}
+
+Public.name = 'MeteOres'
+
+Public.on_nth_tick = {
+  [SPAWN_INTERVAL] = drop_meteors,
+}
+
+Public.level_increase = function()
+  _global.level = math.min(_global.level + 1, _global.max_level)
+end
+
+Public.level_decrease = function()
+  _global.level = math.max(_global.level - 1, 0)
+end
+
+Public.level_reset = function()
+  _global.level = 0
+end
+
+Public.level_set = function(val)
+  _global.level = val
+end
+
+Public.level_get = function()
+  return _global.level
+end
+
+Public.max_get = function()
+  return _global.max_level
+end
+
+return Public

--- a/map_gen/maps/april_fools/modules/meteOres.lua
+++ b/map_gen/maps/april_fools/modules/meteOres.lua
@@ -69,6 +69,7 @@ local function drop_meteors()
     -- Spawn Rock
     if surface.get_tile(map_position).collides_with('ground-tile') then
       surface.create_entity({name = 'rock-huge', position = map_position, move_stuck_players = true,})
+      surface.create_entity({name = 'massive-explosion', position = map_position,})
     end
 
     -- Find nearby entities

--- a/map_gen/maps/april_fools/modules/permanent_factory.lua
+++ b/map_gen/maps/april_fools/modules/permanent_factory.lua
@@ -1,0 +1,77 @@
+-- Any placed entity has a chance to become permanent
+-- WIP
+
+local Global = require 'utils.global'
+
+local BASE_PERCENT = 0.01
+local MAX_RAND = 100
+
+local _global = {
+  level = 0,
+  max_level = 10,
+}
+
+Global.register(_global, function(tbl) _global = tbl end)
+
+-- ============================================================================
+
+local function on_built_entity(event)
+  local entity = event.created_entity
+  if not (entity and entity.valid) then
+    -- Invalid entity
+    return
+  end
+
+  if not (_global and _global.level > 0) then
+    -- Level not enabled
+    return
+  end
+
+  local permanent_percent = _global.level * BASE_PERCENT
+  local rand = math.random(0, MAX_RAND)
+
+  if rand <= MAX_RAND*(1 - permanent_percent) then
+    -- Normal construction
+    return
+  else
+    entity.destructible = false
+    entity.minable = false
+  end
+end
+
+-- ============================================================================
+
+local Public = {}
+
+Public.name = 'Permanent Structures'
+
+Public.events = {
+  [defines.events.on_robot_built_entity] = on_built_entity,
+  [defines.events.on_built_entity] = on_built_entity,
+}
+
+Public.level_increase = function()
+  _global.level = math.min(_global.level + 1, _global.max_level)
+end
+
+Public.level_decrease = function()
+  _global.level = math.max(_global.level - 1, 0)
+end
+
+Public.level_reset = function()
+  _global.level = 0
+end
+
+Public.level_set = function(val)
+  _global.level = val
+end
+
+Public.level_get = function()
+  return _global.level
+end
+
+Public.max_get = function()
+  return _global.max_level
+end
+
+return Public

--- a/map_gen/maps/april_fools/modules/unorganized_recipes.lua
+++ b/map_gen/maps/april_fools/modules/unorganized_recipes.lua
@@ -1,0 +1,95 @@
+-- hides recipe groups from random players. If a player is targeted again, it will revert back to normal
+-- only works with vanilla item-groups.
+-- in future possible change to on_init to populate item_groups with all detected item groups?
+-- WIP
+
+local Global = require 'utils.global'
+
+local BASE_TARGETS = 1 -- how many targets per level
+local CHANGE_TARGET_INTERVAL = _DEBUG and 60 * 10 or 60 * 180 -- 180sec
+
+local _global = {
+  level = 0, -- 1 to enabled by defualt
+  max_level = 10,
+  rand_targets = {},
+}
+
+Global.register(_global, function(tbl) _global = tbl end)
+
+-- ============================================================================
+
+local function clear_targets()
+  for j=1, #_global.rand_targets do
+    _global.rand_targets[j] = nil
+  end
+end
+
+local function change_targets()
+  if not (_global and _global.level > 0) then
+    -- Level not enabled
+    return
+  end
+
+  local num_targets = math.min(#game.connected_players, _global.level * BASE_TARGETS)
+
+  if #game.connected_players > 0 then
+    for j=1, num_targets do
+      local player_index = math.random(1, #game.connected_players)
+      local duplicate = false
+      --check that randomly selected player is not in old list
+      for k=1, #_global.rand_targets do
+        if game.connected_players[player_index].name == _global.rand_targets[k].name then
+          duplicate = true -- target was previously targeted, so enable them and take them off the list
+          _global.rand_targets[k].enable_recipe_groups()
+          _global.rand_targets[k].enable_recipe_subgroups()
+          _global.rand_targets[k] = nil
+        end
+      end
+
+      if duplicate == false then -- this is a new target
+        _global.rand_targets[j] = game.connected_players[player_index]
+        _global.rand_targets[j].disable_recipe_groups()
+        _global.rand_targets[j].disable_recipe_subgroups()
+      end
+    end
+  end
+end
+
+-- ============================================================================
+
+local Public = {}
+
+Public.name = 'Unorganized Recipes'
+
+Public.on_nth_tick = {
+  [CHANGE_TARGET_INTERVAL] = change_targets,
+}
+
+Public.level_increase = function()
+  _global.level = math.min(_global.level + 1, _global.max_level)
+end
+
+Public.level_decrease = function()
+  _global.rand_targets[_global.level] = nil
+  _global.level = math.max(_global.level - 1, 0)
+end
+
+Public.level_reset = function()
+  clear_targets()
+  _global.level = 0
+end
+
+Public.level_set = function(val)
+  clear_targets()
+  _global.level = val
+end
+
+Public.level_get = function()
+  return _global.level
+end
+
+Public.max_get = function()
+  return _global.max_level
+end
+
+return Public

--- a/map_gen/maps/april_fools/pinguin.lua
+++ b/map_gen/maps/april_fools/pinguin.lua
@@ -64,6 +64,7 @@ local modules = {
     require 'map_gen.maps.april_fools.modules.meteOres',           -- Meteors fall from the sky, generating ores, and biters
     require 'map_gen.maps.april_fools.modules.auto_build',         -- Randomly selected players will have their cursor items automatically built nearby for a time, before changing targets
     require 'map_gen.maps.april_fools.modules.unorganized_recipes',-- Randomly selected players will have their recipe groups and subgroups disabled, unorganizing their crafting menu
+    require 'map_gen.maps.april_fools.modules.biter_ores',         -- Biters spawn ores on death, level determines amount
 }
 
 -- if script.active_mods['redmew-data'] then

--- a/map_gen/maps/april_fools/pinguin.lua
+++ b/map_gen/maps/april_fools/pinguin.lua
@@ -63,6 +63,7 @@ local modules = {
     require 'map_gen.maps.april_fools.modules.permanent_factory',  -- Chance to make an entity indestructable
     require 'map_gen.maps.april_fools.modules.meteOres',           -- Meteors fall from the sky, generating ores, and biters
     require 'map_gen.maps.april_fools.modules.auto_build',         -- Randomly selected players will have their cursor items automatically built nearby for a time, before changing targets
+    require 'map_gen.maps.april_fools.modules.unorganized_recipes',-- Randomly selected players will have their recipe groups and subgroups disabled, unorganizing their crafting menu
 }
 
 -- if script.active_mods['redmew-data'] then

--- a/map_gen/maps/april_fools/pinguin.lua
+++ b/map_gen/maps/april_fools/pinguin.lua
@@ -60,6 +60,7 @@ local modules = {
     require 'map_gen.maps.april_fools.modules.rotate_inserters',   -- Chance to randomly rotate an inserter when built
     require 'map_gen.maps.april_fools.modules.rotten_egg',         -- Randomly selected players will produce pollution for a time, before changing targets
     require 'map_gen.maps.april_fools.modules.explosion_scare',    -- Spawns random non-damaging explosions on random players as a jump-scare
+    require 'map_gen.maps.april_fools.modules.permanent_factory',  -- Chance to make an entity indestructable
 }
 
 -- if script.active_mods['redmew-data'] then

--- a/map_gen/maps/april_fools/pinguin.lua
+++ b/map_gen/maps/april_fools/pinguin.lua
@@ -62,6 +62,7 @@ local modules = {
     require 'map_gen.maps.april_fools.modules.explosion_scare',    -- Spawns random non-damaging explosions on random players as a jump-scare
     require 'map_gen.maps.april_fools.modules.permanent_factory',  -- Chance to make an entity indestructable
     require 'map_gen.maps.april_fools.modules.meteOres',           -- Meteors fall from the sky, generating ores, and biters
+    require 'map_gen.maps.april_fools.modules.auto_build',         -- Randomly selected players will have their cursor items automatically built nearby for a time, before changing targets
 }
 
 -- if script.active_mods['redmew-data'] then

--- a/map_gen/maps/april_fools/pinguin.lua
+++ b/map_gen/maps/april_fools/pinguin.lua
@@ -47,7 +47,7 @@ RS.set_map_gen_settings(
 local Event = require 'utils.event'
 
 local modules = {
---[[    require 'map_gen.maps.april_fools.modules.alternative_biters', -- Spawns a random biters on every player that has alt-mode turned on
+    require 'map_gen.maps.april_fools.modules.alternative_biters', -- Spawns a random biters on every player that has alt-mode turned on
     require 'map_gen.maps.april_fools.modules.crazy_chat_colors',  -- Chance to change player's color every time they send a message in chat
     require 'map_gen.maps.april_fools.modules.crazy_toolbar',      -- Randomly replaces quickbar slots with new items
     require 'map_gen.maps.april_fools.modules.enemy_turrets',      -- Chance to change turret to enemy force, and give it ammo/fuel/power
@@ -59,7 +59,7 @@ local modules = {
     require 'map_gen.maps.april_fools.modules.rotate_entities',    -- Chance to randomly rotate an entity when rotated by a player
     require 'map_gen.maps.april_fools.modules.rotate_inserters',   -- Chance to randomly rotate an inserter when built
     require 'map_gen.maps.april_fools.modules.rotten_egg',         -- Randomly selected players will produce pollution for a time, before changing targets
---]]    require 'map_gen.maps.april_fools.modules.explosion_scare',    -- Spawns random non-damaging explosions on random players as a jump-scare
+    require 'map_gen.maps.april_fools.modules.explosion_scare',    -- Spawns random non-damaging explosions on random players as a jump-scare
 }
 
 -- if script.active_mods['redmew-data'] then

--- a/map_gen/maps/april_fools/pinguin.lua
+++ b/map_gen/maps/april_fools/pinguin.lua
@@ -61,6 +61,7 @@ local modules = {
     require 'map_gen.maps.april_fools.modules.rotten_egg',         -- Randomly selected players will produce pollution for a time, before changing targets
     require 'map_gen.maps.april_fools.modules.explosion_scare',    -- Spawns random non-damaging explosions on random players as a jump-scare
     require 'map_gen.maps.april_fools.modules.permanent_factory',  -- Chance to make an entity indestructable
+    require 'map_gen.maps.april_fools.modules.meteOres',           -- Meteors fall from the sky, generating ores, and biters
 }
 
 -- if script.active_mods['redmew-data'] then

--- a/map_gen/maps/april_fools/pinguin.lua
+++ b/map_gen/maps/april_fools/pinguin.lua
@@ -47,7 +47,7 @@ RS.set_map_gen_settings(
 local Event = require 'utils.event'
 
 local modules = {
-    require 'map_gen.maps.april_fools.modules.alternative_biters', -- Spawns a random biters on every player that has alt-mode turned on
+--[[    require 'map_gen.maps.april_fools.modules.alternative_biters', -- Spawns a random biters on every player that has alt-mode turned on
     require 'map_gen.maps.april_fools.modules.crazy_chat_colors',  -- Chance to change player's color every time they send a message in chat
     require 'map_gen.maps.april_fools.modules.crazy_toolbar',      -- Randomly replaces quickbar slots with new items
     require 'map_gen.maps.april_fools.modules.enemy_turrets',      -- Chance to change turret to enemy force, and give it ammo/fuel/power
@@ -59,6 +59,7 @@ local modules = {
     require 'map_gen.maps.april_fools.modules.rotate_entities',    -- Chance to randomly rotate an entity when rotated by a player
     require 'map_gen.maps.april_fools.modules.rotate_inserters',   -- Chance to randomly rotate an inserter when built
     require 'map_gen.maps.april_fools.modules.rotten_egg',         -- Randomly selected players will produce pollution for a time, before changing targets
+--]]    require 'map_gen.maps.april_fools.modules.explosion_scare',    -- Spawns random non-damaging explosions on random players as a jump-scare
 }
 
 -- if script.active_mods['redmew-data'] then
@@ -97,7 +98,7 @@ end
 
 local Toast = require 'features.gui.toast'
 
-local ICEBERG_ENABLE_PERCENTAGE = 0.50
+local ICEBERG_ENABLE_PERCENTAGE = _DEBUG and 1 or 0.50
 local TOAST_DURATION = 10
 
 local function draw_random_effect(max_share)


### PR DESCRIPTION
Adjustments to existing modules: 
- enemy_turrets: non-infinite energy for enemy laser turrets
- floor_is_lava: spawns fire under players at half of max module level

New Modules:
-  Explosion Scare: chooses players to randomly explode (non-damaging) as a jump scare
-  Permanent Factory: a very small chance for entities to become permanent when placed.
- MeteOres: spawns a meteor (rock) with ores and biters at a random point on the map. In theory can be used as the only source of ores and biters as long as oil is kept in map-gen, with some tweaks to module settings.
- Auto Build: Selects random players, and automatically builds the item in their cursor nearby for a while, before changing targets.
- Unorganized Recipes: Selects random players and toggles whether their crafting menus are organized (normal) or unorganized (chaos) by disabling crafting groups and subgroups.
- Biter Ores: Spawns ores on biter/worm/spawner death. Can be set to random, or to form into more normal patches.